### PR TITLE
Update to newer version of ember-cli & friends

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-ruby-sass": "^0.3.0",
     "broccoli-static-compiler": "^0.2.1",
-    "ember-cli": "0.1.5",
-    "ember-cli-coffeescript": "^0.4.0",
+    "ember-cli": "0.2.0",
+    "ember-cli-coffeescript": "^0.5.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-esnext": "0.1.1",
@@ -35,6 +35,7 @@
     "ember-data": "^1.0.0-beta.14.1",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.4.2",
+    "rimraf": "2.2.8"
   }
 }


### PR DESCRIPTION
This was a cascade of required upgrades due to a bug in a deep
dependency of ember-cli: rimraf. For more details, see 
https://github.com/ember-cli/ember-cli/issues/3486.

Upgrade rimraf => upgrade glob => upgrade ember-cli
   => ember-cli-coffeescript.

What a nightmare.
